### PR TITLE
Fix: incorrect cache size when moving or zooming

### DIFF
--- a/CentrED/Map/MapManager.cs
+++ b/CentrED/Map/MapManager.cs
@@ -350,7 +350,7 @@ public class MapManager {
             }
 
             if (Client.Running) {
-                Client.ResizeCache((_prevViewRange.Width * _prevViewRange.Height * 4) +
+                Client.ResizeCache((_prevViewRange.Width * _prevViewRange.Height / 8) +
                                    requested.Count * 4);
                 Client.LoadBlocks(requested);
             }

--- a/CentrED/Map/MapManager.cs
+++ b/CentrED/Map/MapManager.cs
@@ -350,7 +350,8 @@ public class MapManager {
             }
 
             if (Client.Running) {
-                Client.ResizeCache(requested.Count * 4);
+                Client.ResizeCache((_prevViewRange.Width * _prevViewRange.Height * 4) +
+                                   requested.Count * 4);
                 Client.LoadBlocks(requested);
             }
 


### PR DESCRIPTION
Fix to prevent freezing due to cache size getting set to 0