### PR TITLE
Fix: Prevent crash when creating password

### DIFF
--- a/Server/Config/ConfigRoot.cs
+++ b/Server/Config/ConfigRoot.cs
@@ -144,7 +144,8 @@ public class ConfigRoot {
             if (key.Key == ConsoleKey.Enter)
                 break;
             if (key.Key == ConsoleKey.Backspace)
-                password = password.Remove(password.Length - 1);
+                if (password.Length > 0)
+                    password = password.Remove(password.Length - 1);
             else {
                 password += key.KeyChar;
             }


### PR DESCRIPTION
When you are asked to enter a password and press backspace with no input, the server will crash