### PR TITLE
Sequential Tile Sets Implementation

### DIFF
--- a/CentrED/IO/Models/Profile.cs
+++ b/CentrED/IO/Models/Profile.cs
@@ -5,11 +5,12 @@ namespace CentrED.IO.Models;
 
 public class Profile
 {
-    
     private const string PROFILE_FILE = "profile.json";
     private const string LOCATIONS_FILE = "locations.json";
     private const string LAND_TILE_SETS_FILE = "landtilesets.json";
     private const string STATIC_TILE_SETS_FILE = "statictilesets.json";
+    private const string SEQUENTIAL_LAND_TILE_SETS_FILE = "sequential_landtilesets.json";
+    private const string SEQUENTIAL_STATIC_TILE_SETS_FILE = "sequential_statictilesets.json";
     private const string HUE_SETS_FILE = "huesets.json";
     private const string LAND_BRUSH_FILE = "landbrush.json";
     
@@ -23,6 +24,8 @@ public class Profile
     public Dictionary<string, RadarFavorite> RadarFavorites { get; set; } = new();
     [JsonIgnore] public Dictionary<string, SortedSet<ushort>> LandTileSets { get; set; } = new();
     [JsonIgnore] public Dictionary<string, SortedSet<ushort>> StaticTileSets { get; set; } = new();
+    [JsonIgnore] public Dictionary<string, List<ushort>> SequentialLandTileSets { get; set; } = new();
+    [JsonIgnore] public Dictionary<string, List<ushort>> SequentialStaticTileSets { get; set; } = new();
     [JsonIgnore] public Dictionary<string, SortedSet<ushort>> HueSets { get; set; } = new();
     [JsonIgnore] public Dictionary<string, LandBrush> LandBrush { get; set; } = new();
     
@@ -42,6 +45,8 @@ public class Profile
         File.WriteAllText(Path.Join(profileDir, LOCATIONS_FILE), JsonSerializer.Serialize(RadarFavorites, options));
         File.WriteAllText(Path.Join(profileDir, LAND_TILE_SETS_FILE), JsonSerializer.Serialize(LandTileSets, options));
         File.WriteAllText(Path.Join(profileDir, STATIC_TILE_SETS_FILE), JsonSerializer.Serialize(StaticTileSets, options));
+        File.WriteAllText(Path.Join(profileDir, SEQUENTIAL_LAND_TILE_SETS_FILE), JsonSerializer.Serialize(SequentialLandTileSets, options));
+        File.WriteAllText(Path.Join(profileDir, SEQUENTIAL_STATIC_TILE_SETS_FILE), JsonSerializer.Serialize(SequentialStaticTileSets, options));
         File.WriteAllText(Path.Join(profileDir, HUE_SETS_FILE), JsonSerializer.Serialize(HueSets, options));
         File.WriteAllText(Path.Join(profileDir, LAND_BRUSH_FILE), JsonSerializer.Serialize(LandBrush, Models.LandBrush.JsonOptions));
     }
@@ -57,23 +62,32 @@ public class Profile
             return null;
         profile.Name = dir.Name;
         
-        var favorites  = Deserialize<Dictionary<string, RadarFavorite>>(Path.Join(profileDir, LOCATIONS_FILE));
+        var favorites = Deserialize<Dictionary<string, RadarFavorite>>(Path.Join(profileDir, LOCATIONS_FILE));
         if (favorites != null)
             profile.RadarFavorites = favorites;
         
-        var landTileSets  = Deserialize<Dictionary<string, SortedSet<ushort>>>(Path.Join(profileDir, LAND_TILE_SETS_FILE));
+        var landTileSets = Deserialize<Dictionary<string, SortedSet<ushort>>>(Path.Join(profileDir, LAND_TILE_SETS_FILE));
         if (landTileSets != null)
             profile.LandTileSets = landTileSets;
         
-        var staticTileSets  = Deserialize<Dictionary<string, SortedSet<ushort>>>(Path.Join(profileDir, STATIC_TILE_SETS_FILE));
+        var staticTileSets = Deserialize<Dictionary<string, SortedSet<ushort>>>(Path.Join(profileDir, STATIC_TILE_SETS_FILE));
         if (staticTileSets != null)
             profile.StaticTileSets = staticTileSets;
+            
+        // Change the sequence deserialization to use List instead of SortedSet
+        var sequentialLandTileSets = Deserialize<Dictionary<string, List<ushort>>>(Path.Join(profileDir, SEQUENTIAL_LAND_TILE_SETS_FILE));
+        if (sequentialLandTileSets != null)
+            profile.SequentialLandTileSets = sequentialLandTileSets;
+            
+        var sequentialStaticTileSets = Deserialize<Dictionary<string, List<ushort>>>(Path.Join(profileDir, SEQUENTIAL_STATIC_TILE_SETS_FILE));
+        if (sequentialStaticTileSets != null)
+            profile.SequentialStaticTileSets = sequentialStaticTileSets;
         
-        var huesets  = Deserialize<Dictionary<string, SortedSet<ushort>>>(Path.Join(profileDir, HUE_SETS_FILE));
+        var huesets = Deserialize<Dictionary<string, SortedSet<ushort>>>(Path.Join(profileDir, HUE_SETS_FILE));
         if (huesets != null)
             profile.HueSets = huesets;
         
-        var landBrush  = Deserialize<Dictionary<string, LandBrush>>(Path.Join(profileDir, LAND_BRUSH_FILE), Models.LandBrush.JsonOptions);
+        var landBrush = Deserialize<Dictionary<string, LandBrush>>(Path.Join(profileDir, LAND_BRUSH_FILE), Models.LandBrush.JsonOptions);
         if (landBrush != null)
             profile.LandBrush = landBrush;
         

--- a/CentrED/IO/Models/Profile.cs
+++ b/CentrED/IO/Models/Profile.cs
@@ -9,12 +9,10 @@ public class Profile
     private const string LOCATIONS_FILE = "locations.json";
     private const string LAND_TILE_SETS_FILE = "landtilesets.json";
     private const string STATIC_TILE_SETS_FILE = "statictilesets.json";
-    private const string SEQUENTIAL_LAND_TILE_SETS_FILE = "sequential_landtilesets.json";
-    private const string SEQUENTIAL_STATIC_TILE_SETS_FILE = "sequential_statictilesets.json";
     private const string HUE_SETS_FILE = "huesets.json";
     private const string LAND_BRUSH_FILE = "landbrush.json";
     
-    [JsonIgnore] public string Name { get; set; }
+    [JsonIgnore] public string Name { get; set; } = "";
     public string Hostname { get; set; } = "127.0.0.1";
     public int Port { get; set; } = 2597;
     public string Username { get; set; } = "";
@@ -22,10 +20,8 @@ public class Profile
     public string ClientVersion { get; set; } = "";
     [JsonIgnore]
     public Dictionary<string, RadarFavorite> RadarFavorites { get; set; } = new();
-    [JsonIgnore] public Dictionary<string, SortedSet<ushort>> LandTileSets { get; set; } = new();
-    [JsonIgnore] public Dictionary<string, SortedSet<ushort>> StaticTileSets { get; set; } = new();
-    [JsonIgnore] public Dictionary<string, List<ushort>> SequentialLandTileSets { get; set; } = new();
-    [JsonIgnore] public Dictionary<string, List<ushort>> SequentialStaticTileSets { get; set; } = new();
+    [JsonIgnore] public Dictionary<string, List<ushort>> LandTileSets { get; set; } = new();
+    [JsonIgnore] public Dictionary<string, List<ushort>> StaticTileSets { get; set; } = new();
     [JsonIgnore] public Dictionary<string, SortedSet<ushort>> HueSets { get; set; } = new();
     [JsonIgnore] public Dictionary<string, LandBrush> LandBrush { get; set; } = new();
     
@@ -45,8 +41,6 @@ public class Profile
         File.WriteAllText(Path.Join(profileDir, LOCATIONS_FILE), JsonSerializer.Serialize(RadarFavorites, options));
         File.WriteAllText(Path.Join(profileDir, LAND_TILE_SETS_FILE), JsonSerializer.Serialize(LandTileSets, options));
         File.WriteAllText(Path.Join(profileDir, STATIC_TILE_SETS_FILE), JsonSerializer.Serialize(StaticTileSets, options));
-        File.WriteAllText(Path.Join(profileDir, SEQUENTIAL_LAND_TILE_SETS_FILE), JsonSerializer.Serialize(SequentialLandTileSets, options));
-        File.WriteAllText(Path.Join(profileDir, SEQUENTIAL_STATIC_TILE_SETS_FILE), JsonSerializer.Serialize(SequentialStaticTileSets, options));
         File.WriteAllText(Path.Join(profileDir, HUE_SETS_FILE), JsonSerializer.Serialize(HueSets, options));
         File.WriteAllText(Path.Join(profileDir, LAND_BRUSH_FILE), JsonSerializer.Serialize(LandBrush, Models.LandBrush.JsonOptions));
     }
@@ -66,22 +60,13 @@ public class Profile
         if (favorites != null)
             profile.RadarFavorites = favorites;
         
-        var landTileSets = Deserialize<Dictionary<string, SortedSet<ushort>>>(Path.Join(profileDir, LAND_TILE_SETS_FILE));
+        var landTileSets = Deserialize<Dictionary<string, List<ushort>>>(Path.Join(profileDir, LAND_TILE_SETS_FILE));
         if (landTileSets != null)
             profile.LandTileSets = landTileSets;
         
-        var staticTileSets = Deserialize<Dictionary<string, SortedSet<ushort>>>(Path.Join(profileDir, STATIC_TILE_SETS_FILE));
+        var staticTileSets = Deserialize<Dictionary<string, List<ushort>>>(Path.Join(profileDir, STATIC_TILE_SETS_FILE));
         if (staticTileSets != null)
             profile.StaticTileSets = staticTileSets;
-            
-        // Change the sequence deserialization to use List instead of SortedSet
-        var sequentialLandTileSets = Deserialize<Dictionary<string, List<ushort>>>(Path.Join(profileDir, SEQUENTIAL_LAND_TILE_SETS_FILE));
-        if (sequentialLandTileSets != null)
-            profile.SequentialLandTileSets = sequentialLandTileSets;
-            
-        var sequentialStaticTileSets = Deserialize<Dictionary<string, List<ushort>>>(Path.Join(profileDir, SEQUENTIAL_STATIC_TILE_SETS_FILE));
-        if (sequentialStaticTileSets != null)
-            profile.SequentialStaticTileSets = sequentialStaticTileSets;
         
         var huesets = Deserialize<Dictionary<string, SortedSet<ushort>>>(Path.Join(profileDir, HUE_SETS_FILE));
         if (huesets != null)

--- a/CentrED/Map/MapManager.cs
+++ b/CentrED/Map/MapManager.cs
@@ -70,7 +70,6 @@ public class MapManager
     public bool UseSequentialTileSet = false;
     internal int _currentSequenceIndex = 0;
     internal bool _isFirstTileAfterClick = false; // Track first tile after mouse press
-    private bool _wasDrawing = false;
     public bool WalkableSurfaces = false;
     public bool FlatView = false;
     public bool FlatShowHeight = false;
@@ -751,17 +750,6 @@ public class MapManager
             }
             _prevKeyState = keyState;
         }
-
-        // Check if we're drawing with the mouse button
-        bool isDrawing = isActive && Mouse.GetState().LeftButton == ButtonState.Pressed;
-        
-        // If we were drawing but stopped, reset the sequence
-        if (_wasDrawing && !isDrawing && UseSequentialTileSet)
-        {
-            ResetSequence();
-        }
-        
-        _wasDrawing = isDrawing;
 
         Camera.Update();
         CalculateViewRange(Camera, out var newViewRange);

--- a/CentrED/Map/MapManager.cs
+++ b/CentrED/Map/MapManager.cs
@@ -67,6 +67,10 @@ public class MapManager
     public int VirtualLayerZ;
     public bool UseVirtualLayer = false;
     public bool UseRandomTileSet = false;
+    public bool UseSequentialTileSet = false;
+    internal int _currentSequenceIndex = 0;
+    internal bool _isFirstTileAfterClick = false; // Track first tile after mouse press
+    private bool _wasDrawing = false;
     public bool WalkableSurfaces = false;
     public bool FlatView = false;
     public bool FlatShowHeight = false;
@@ -94,6 +98,12 @@ public class MapManager
 
     public int[] ValidLandIds { get; private set; }
     public int[] ValidStaticIds { get; private set; }
+    
+    public void ResetSequence()
+    {
+        _currentSequenceIndex = 0;
+        _isFirstTileAfterClick = true;
+    }
 
     public MapManager(GraphicsDevice gd)
     {
@@ -741,6 +751,17 @@ public class MapManager
             }
             _prevKeyState = keyState;
         }
+
+        // Check if we're drawing with the mouse button
+        bool isDrawing = isActive && Mouse.GetState().LeftButton == ButtonState.Pressed;
+        
+        // If we were drawing but stopped, reset the sequence
+        if (_wasDrawing && !isDrawing && UseSequentialTileSet)
+        {
+            ResetSequence();
+        }
+        
+        _wasDrawing = isDrawing;
 
         Camera.Update();
         CalculateViewRange(Camera, out var newViewRange);

--- a/CentrED/Tools/BaseTool.cs
+++ b/CentrED/Tools/BaseTool.cs
@@ -9,6 +9,33 @@ namespace CentrED.Tools;
 //BaseTool allows for out of the box continuous and area drawing
 public abstract class BaseTool : Tool
 {
+    // Properties to track area operations
+    protected bool IsAreaOperation { get; private set; }
+    protected ushort AreaStartX { get; private set; }
+    protected ushort AreaStartY { get; private set; }
+    protected ushort AreaEndX { get; private set; }
+    protected ushort AreaEndY { get; private set; }
+    
+    public void OnAreaOperationStart(ushort x, ushort y)
+    {
+        IsAreaOperation = true;
+        AreaStartX = x;
+        AreaStartY = y;
+        AreaEndX = x;
+        AreaEndY = y;
+    }
+    
+    public void OnAreaOperationUpdate(ushort x, ushort y)
+    {
+        AreaEndX = x;
+        AreaEndY = y;
+    }
+    
+    public void OnAreaOperationEnd()
+    {
+        IsAreaOperation = false;
+    }
+    
     protected static readonly Random Random = Random.Shared;
     protected abstract void GhostApply(TileObject? o);
     protected abstract void GhostClear(TileObject? o);
@@ -67,6 +94,8 @@ public abstract class BaseTool : Tool
                 to = CEDGame.MapManager.LandTiles[to.Tile.X, to.Tile.Y];
             }
             _areaStartTile = to;
+            
+            OnAreaOperationStart(to.Tile.X, to.Tile.Y);
         }
         CEDClient.BeginUndoGroup();
         
@@ -74,19 +103,18 @@ public abstract class BaseTool : Tool
         if (CEDGame.MapManager.UseSequentialTileSet)
         {
             CEDGame.MapManager.ResetSequence();
-        }
-        
-        // ALWAYS apply ghost to the initial tile
-        if (o != null)
-        {
-            var tilesWindow = UIManager.GetWindow<TilesWindow>();
-            TileObject to = o;
-            if (CEDGame.MapManager.UseVirtualLayer && tilesWindow.LandMode && o is VirtualLayerTile)
+
+            // ALWAYS apply ghost to the initial tile
+            if (o != null)
             {
-                to = CEDGame.MapManager.LandTiles[to.Tile.X, to.Tile.Y];
+                var tilesWindow = UIManager.GetWindow<TilesWindow>();
+                TileObject to = o;
+                if (CEDGame.MapManager.UseVirtualLayer && tilesWindow.LandMode && o is VirtualLayerTile)
+                {
+                    to = CEDGame.MapManager.LandTiles[to.Tile.X, to.Tile.Y];
+                }
+                GhostApply(to);
             }
-            // Console.WriteLine($"GhostApply at {o.Tile.X},{o.Tile.Y} - INITIAL CLICK");
-            GhostApply(to);
         }
     }
     
@@ -122,6 +150,18 @@ public abstract class BaseTool : Tool
         }
         _pressed = false;
         _areaStartTile = null;
+        
+        if (_areaMode)
+        {
+            OnAreaOperationEnd();
+        }
+        
+        // Reset sequence when mouse is released (drawing ends)
+        if (CEDGame.MapManager.UseSequentialTileSet)
+        {
+            CEDGame.MapManager.ResetSequence();
+        }
+        
         CEDClient.EndUndoGroup();
     }
 
@@ -131,6 +171,11 @@ public abstract class BaseTool : Tool
         if (o == null)
             return;
 
+        if (_areaMode && _pressed && o != null)
+        {
+            OnAreaOperationUpdate(o.Tile.X, o.Tile.Y);
+        }
+        
         var tilesWindow = UIManager.GetWindow<TilesWindow>();
 
         if (_areaMode && _pressed)
@@ -203,5 +248,70 @@ public abstract class BaseTool : Tool
     {
         GhostApply(o);
         InternalApply(o);
+    }
+
+    protected virtual ushort GetSequentialTileId(ushort x, ushort y)
+    {
+        var tilesWindow = UIManager.GetWindow<TilesWindow>();
+        
+        if (!MapManager.UseSequentialTileSet || tilesWindow.ActiveTileSetValues.Length == 0)
+            return tilesWindow.ActiveId;
+        
+        // For preview mode (not pressed and not in area operation), always use first tile
+        if (!_pressed && !IsAreaOperation)
+            return tilesWindow.ActiveTileSetValues[0];
+        
+        // If we're not doing an area operation, just advance through the sequence normally
+        if (!IsAreaOperation)
+            return tilesWindow.GetNextSequentialId();
+        
+        // For area operations, always use the first tile from the set for the starting point
+        if (x == AreaStartX && y == AreaStartY)
+            return tilesWindow.ActiveTileSetValues[0];
+        
+        // Calculate the Manhattan distance from the starting point
+        int distanceX = Math.Abs(x - AreaStartX);
+        int distanceY = Math.Abs(y - AreaStartY);
+        
+        // Determine the direction (used for ordering tiles at the same distance)
+        bool isXPositive = x >= AreaStartX;
+        bool isYPositive = y >= AreaStartY;
+        
+        int sequenceIndex;
+        
+        // If we're moving along the X axis (same Y)
+        if (y == AreaStartY) {
+            sequenceIndex = isXPositive ? distanceX : distanceX;
+        }
+        // If we're moving along the Y axis (same X)
+        else if (x == AreaStartX) {
+            sequenceIndex = isYPositive ? distanceY : distanceY;
+        }
+        // If we're moving diagonally or in a rectangular pattern
+        else {
+            // Calculate position in 2D grid, starting from AreaStartX,AreaStartY
+            int width = Math.Abs(AreaEndX - AreaStartX) + 1;
+            
+            // Calculate normalized coordinates from starting point
+            int normX = x - AreaStartX;
+            int normY = y - AreaStartY;
+            
+            // Create a sequence based on row-major order from starting point
+            sequenceIndex = Math.Abs(normY) * width + Math.Abs(normX);
+            
+            // Add an offset if we're in a negative direction
+            if (!isXPositive) sequenceIndex += 1;
+            if (!isYPositive) sequenceIndex += 2;
+        }
+        
+        // Make sure the first tile (index 0) is only for the exact starting position
+        if (sequenceIndex == 0)
+            sequenceIndex = 1;
+        
+        // Wrap around if needed
+        int arrayLength = tilesWindow.ActiveTileSetValues.Length;
+        sequenceIndex = sequenceIndex % arrayLength;
+        
+        return tilesWindow.ActiveTileSetValues[sequenceIndex];
     }
 }

--- a/CentrED/Tools/BaseTool.cs
+++ b/CentrED/Tools/BaseTool.cs
@@ -64,11 +64,30 @@ public abstract class BaseTool : Tool
             var tilesWindow = UIManager.GetWindow<TilesWindow>();
             if (CEDGame.MapManager.UseVirtualLayer && tilesWindow.LandMode && o is VirtualLayerTile)
             {
-                to = CEDGame.MapManager.LandTiles[o.Tile.X, o.Tile.Y];
+                to = CEDGame.MapManager.LandTiles[to.Tile.X, to.Tile.Y];
             }
             _areaStartTile = to;
         }
         CEDClient.BeginUndoGroup();
+        
+        // For sequential tile sets, reset the sequence but DON'T skip GhostApply
+        if (CEDGame.MapManager.UseSequentialTileSet)
+        {
+            CEDGame.MapManager.ResetSequence();
+        }
+        
+        // ALWAYS apply ghost to the initial tile
+        if (o != null)
+        {
+            var tilesWindow = UIManager.GetWindow<TilesWindow>();
+            TileObject to = o;
+            if (CEDGame.MapManager.UseVirtualLayer && tilesWindow.LandMode && o is VirtualLayerTile)
+            {
+                to = CEDGame.MapManager.LandTiles[to.Tile.X, to.Tile.Y];
+            }
+            // Console.WriteLine($"GhostApply at {o.Tile.X},{o.Tile.Y} - INITIAL CLICK");
+            GhostApply(to);
+        }
     }
     
     public sealed override void OnMouseReleased(TileObject? o)

--- a/CentrED/Tools/DrawTool.cs
+++ b/CentrED/Tools/DrawTool.cs
@@ -38,10 +38,6 @@ public class DrawTool : BaseTool
             if (!randomWasChecked && MapManager.UseRandomTileSet)
             {
                 MapManager.UseSequentialTileSet = false;
-                
-                // Reset tile set selection when switching modes
-                var tilesWindow = UIManager.GetWindow<TilesWindow>();
-                tilesWindow.ResetTileSetSelection();
             }
         }
 
@@ -52,16 +48,6 @@ public class DrawTool : BaseTool
             if (!sequentialWasChecked && MapManager.UseSequentialTileSet)
             {
                 MapManager.UseRandomTileSet = false;
-                
-                // Reset tile set selection when switching modes
-                var tilesWindow = UIManager.GetWindow<TilesWindow>();
-                tilesWindow.ResetTileSetSelection();
-            }
-            else if (sequentialWasChecked && !MapManager.UseSequentialTileSet)
-            {
-                // Also reset when turning off sequential mode
-                var tilesWindow = UIManager.GetWindow<TilesWindow>();
-                tilesWindow.ResetTileSetSelection();
             }
         }
 
@@ -134,12 +120,12 @@ public class DrawTool : BaseTool
         var tilesWindow = UIManager.GetWindow<TilesWindow>();
         if (tilesWindow.StaticMode)
         {
-            // Get the right tile ID based on sequence
+            // Get the right tile ID based on sequence and position
             ushort tileId;
-            if (_pressed && MapManager.UseSequentialTileSet)
+            if (MapManager.UseSequentialTileSet)
             {
-                // Always use GetNextSequentialId which will manage sequence properly
-                tileId = tilesWindow.GetNextSequentialId();
+                // Use position-aware sequential ID calculation
+                tileId = GetSequentialTileId(o.Tile.X, o.Tile.Y);
             }
             else
             {
@@ -193,11 +179,12 @@ public class DrawTool : BaseTool
         {
             o.Visible = false;
             
-            // Same approach for land tiles
+            // Get the right tile ID based on sequence and position
             ushort tileId;
-            if (_pressed && MapManager.UseSequentialTileSet)
+            if (MapManager.UseSequentialTileSet)
             {
-                tileId = tilesWindow.GetNextSequentialId();
+                // Use position-aware sequential ID calculation
+                tileId = GetSequentialTileId(o.Tile.X, o.Tile.Y);
             }
             else
             {

--- a/CentrED/UI/Windows/TilesWindow.cs
+++ b/CentrED/UI/Windows/TilesWindow.cs
@@ -525,26 +525,16 @@ public class TilesWindow : Window
     // Helper method to get the appropriate tile sets collection
     private object GetCurrentTileSets()
     {
-        if (CEDGame.MapManager.UseSequentialTileSet)
-        {
-            return LandMode ? 
-                ProfileManager.ActiveProfile.SequentialLandTileSets : 
-                ProfileManager.ActiveProfile.SequentialStaticTileSets;
-        }
-        else
-        {
-            return LandMode ?
-                ProfileManager.ActiveProfile.LandTileSets :
-                ProfileManager.ActiveProfile.StaticTileSets;
-        }
+        return LandMode ?
+            ProfileManager.ActiveProfile.LandTileSets :
+            ProfileManager.ActiveProfile.StaticTileSets;
     }
 
     private void DrawTileSets()
     {
         ImGui.BeginChild("TileSets");
 
-        // Update title based on sequential mode
-        ImGui.Text(CEDGame.MapManager.UseSequentialTileSet ? "Sequential Tile Set" : "Tile Set");
+        ImGui.Text("Tile Set");
 
         if (ImGui.Button("New"))
         {
@@ -560,21 +550,11 @@ public class TilesWindow : Window
         }
         ImGui.EndDisabled();
 
-        string[] names;
-        if (CEDGame.MapManager.UseSequentialTileSet)
-        {
-            var tileSets = LandMode ? 
-                ProfileManager.ActiveProfile.SequentialLandTileSets : 
-                ProfileManager.ActiveProfile.SequentialStaticTileSets;
-            names = new[] { String.Empty }.Concat(tileSets.Keys).ToArray();
-        }
-        else
-        {
-            var tileSets = LandMode ?
-                ProfileManager.ActiveProfile.LandTileSets :
-                ProfileManager.ActiveProfile.StaticTileSets;
-            names = new[] { String.Empty }.Concat(tileSets.Keys).ToArray();
-        }
+        var tileSets = LandMode ?
+            ProfileManager.ActiveProfile.LandTileSets :
+            ProfileManager.ActiveProfile.StaticTileSets;
+            
+        string[] names = new[] { String.Empty }.Concat(tileSets.Keys).ToArray();
 
         if (ImGui.Combo("", ref _tileSetIndex, names, names.Length))
         {
@@ -585,23 +565,11 @@ public class TilesWindow : Window
             }
             else
             {
-                if (CEDGame.MapManager.UseSequentialTileSet)
-                {
-                    var tileSets = LandMode ? 
-                        ProfileManager.ActiveProfile.SequentialLandTileSets : 
-                        ProfileManager.ActiveProfile.SequentialStaticTileSets;
-                    ActiveTileSetValues = tileSets[_tileSetName].ToArray();
-                }
-                else
-                {
-                    var tileSets = LandMode ?
-                        ProfileManager.ActiveProfile.LandTileSets :
-                        ProfileManager.ActiveProfile.StaticTileSets;
-                    ActiveTileSetValues = tileSets[_tileSetName].ToArray();
-                }
+                ActiveTileSetValues = tileSets[_tileSetName].ToArray();
             }
             _tileSetSelectedId = 0;
         }
+        
         ImGui.BeginChild("TileSetTable");
         if (ImGui.BeginTable("TileSetTable", 3) && CEDClient.Initialized)
         {
@@ -625,7 +593,7 @@ public class TilesWindow : Window
                         if (ImGui.Selectable
                             (
                                 $"##tileset{tileInfo.RealIndex}_{rowIndex}", // Add rowIndex to make ID unique
-                               _tileSetSelectedId == tileIndex,
+                                _tileSetSelectedId == tileIndex,
                                 ImGuiSelectableFlags.SpanAllColumns,
                                 new Vector2(0, TilesDimensions.Y)
                             ))
@@ -634,22 +602,19 @@ public class TilesWindow : Window
                         }
                         if (ImGui.BeginPopupContextItem())
                         {
-                            // Only show Up/Down buttons in sequential mode
-                            if (CEDGame.MapManager.UseSequentialTileSet)
+                            if (ImGui.Button("Move Up"))
                             {
-                                if (ImGui.Button("Move Up"))
-                                {
-                                    MoveSequentialTileAtIndex(rowIndex); // Use array index instead of tile ID
-                                    ImGui.CloseCurrentPopup();
-                                }
-                                ImGui.SameLine();
-                                if (ImGui.Button("Move Down"))
-                                {
-                                    MoveSequentialTileAtIndex(rowIndex + 1); // Use array index instead of tile ID
-                                    ImGui.CloseCurrentPopup();
-                                }
-                                ImGui.Separator();
+                                MoveSequentialTileAtIndex(rowIndex); // Use array index instead of tile ID
+                                ImGui.CloseCurrentPopup();
                             }
+                            ImGui.SameLine();
+                            if (ImGui.Button("Move Down"))
+                            {
+                                MoveSequentialTileAtIndex(rowIndex + 1); // Use array index instead of tile ID
+                                ImGui.CloseCurrentPopup();
+                            }
+                            ImGui.Separator();
+
                             
                             if (ImGui.Button("Remove"))
                             {
@@ -692,22 +657,12 @@ public class TilesWindow : Window
             ImGui.InputText("", ref _tileSetNewName, 32);
             if (ImGui.Button("Add"))
             {
-                if (CEDGame.MapManager.UseSequentialTileSet)
-                {
-                    var tileSets = LandMode ? 
-                        ProfileManager.ActiveProfile.SequentialLandTileSets : 
-                        ProfileManager.ActiveProfile.SequentialStaticTileSets;
-                    tileSets.Add(_tileSetNewName, new List<ushort>());
-                    _tileSetIndex = Array.IndexOf(tileSets.Keys.ToArray(), _tileSetNewName) + 1;
-                }
-                else
-                {
-                    var tileSets = LandMode ?
-                        ProfileManager.ActiveProfile.LandTileSets :
-                        ProfileManager.ActiveProfile.StaticTileSets;
-                    tileSets.Add(_tileSetNewName, new SortedSet<ushort>());
-                    _tileSetIndex = Array.IndexOf(tileSets.Keys.ToArray(), _tileSetNewName) + 1;
-                }
+                var currentTileSets = LandMode ? 
+                    ProfileManager.ActiveProfile.LandTileSets : 
+                    ProfileManager.ActiveProfile.StaticTileSets;
+                    
+                currentTileSets.Add(_tileSetNewName, new List<ushort>());
+                _tileSetIndex = Array.IndexOf(currentTileSets.Keys.ToArray(), _tileSetNewName) + 1;
                 _tileSetName = _tileSetNewName;
                 ActiveTileSetValues = Empty;
                 _tileSetSelectedId = 0;
@@ -732,20 +687,11 @@ public class TilesWindow : Window
             ImGui.Text($"Are you sure you want to delete tile set '{_tileSetName}'?");
             if (ImGui.Button("Yes"))
             {
-                if (CEDGame.MapManager.UseSequentialTileSet)
-                {
-                    var tileSets = LandMode ? 
-                        ProfileManager.ActiveProfile.SequentialLandTileSets : 
-                        ProfileManager.ActiveProfile.SequentialStaticTileSets;
-                    tileSets.Remove(_tileSetName);
-                }
-                else
-                {
-                    var tileSets = LandMode ?
-                        ProfileManager.ActiveProfile.LandTileSets :
-                        ProfileManager.ActiveProfile.StaticTileSets;
-                    tileSets.Remove(_tileSetName);
-                }
+                var currentTileSets = LandMode ? 
+                    ProfileManager.ActiveProfile.LandTileSets : 
+                    ProfileManager.ActiveProfile.StaticTileSets;
+                    
+                currentTileSets.Remove(_tileSetName);
                 ProfileManager.Save();
                 _tileSetIndex--;
                 ImGui.CloseCurrentPopup();
@@ -762,12 +708,9 @@ public class TilesWindow : Window
 
     private void MoveSequentialTileAtIndex(int index)
     {
-        if (!CEDGame.MapManager.UseSequentialTileSet)
-            return;
-            
         var tileSets = LandMode ? 
-            ProfileManager.ActiveProfile.SequentialLandTileSets : 
-            ProfileManager.ActiveProfile.SequentialStaticTileSets;
+            ProfileManager.ActiveProfile.LandTileSets : 
+            ProfileManager.ActiveProfile.StaticTileSets;
             
         var tileSet = tileSets[_tileSetName];
         
@@ -797,37 +740,21 @@ public class TilesWindow : Window
         if (index < 0)
             return;
             
-        if (CEDGame.MapManager.UseSequentialTileSet)
-        {
-            var tileSets = LandMode ? 
-                ProfileManager.ActiveProfile.SequentialLandTileSets : 
-                ProfileManager.ActiveProfile.SequentialStaticTileSets;
-                
-            var tileSet = tileSets[_tileSetName];
+        var tileSets = LandMode ? 
+            ProfileManager.ActiveProfile.LandTileSets : 
+            ProfileManager.ActiveProfile.StaticTileSets;
             
-            if (index < tileSet.Count)
-            {
-                var newOrder = tileSet.ToList();
-                newOrder.RemoveAt(index);
-                
-                tileSet.Clear();
-                foreach (var tile in newOrder)
-                    tileSet.Add(tile);
-                    
-                ActiveTileSetValues = tileSet.ToArray();
-                ProfileManager.Save();
-            }
-        }
-        else
+        var tileSet = tileSets[_tileSetName];
+        
+        if (index < tileSet.Count)
         {
-            // For non-sequential, just keep using the old method
-            var tileSets = LandMode ?
-                ProfileManager.ActiveProfile.LandTileSets :
-                ProfileManager.ActiveProfile.StaticTileSets;
+            var newOrder = tileSet.ToList();
+            newOrder.RemoveAt(index);
+            
+            tileSet.Clear();
+            foreach (var tile in newOrder)
+                tileSet.Add(tile);
                 
-            var id = ActiveTileSetValues[index];
-            var tileSet = tileSets[_tileSetName];
-            tileSet.Remove(id);
             ActiveTileSetValues = tileSet.ToArray();
             ProfileManager.Save();
         }
@@ -835,56 +762,28 @@ public class TilesWindow : Window
 
     private void AddToTileSet(ushort id)
     {
-        if (CEDGame.MapManager.UseSequentialTileSet)
-        {
-            var tileSets = LandMode ? 
-                ProfileManager.ActiveProfile.SequentialLandTileSets : 
-                ProfileManager.ActiveProfile.SequentialStaticTileSets;
-                
-            var tileSet = tileSets[_tileSetName];
+        var tileSets = LandMode ? 
+            ProfileManager.ActiveProfile.LandTileSets : 
+            ProfileManager.ActiveProfile.StaticTileSets;
             
-            // Allow duplications in sequential mode by always adding the tile
-            tileSet.Add(id);
-                
-            ActiveTileSetValues = tileSet.ToArray();
-        }
-        else
-        {
-            var tileSets = LandMode ?
-                ProfileManager.ActiveProfile.LandTileSets :
-                ProfileManager.ActiveProfile.StaticTileSets;
-                
-            var tileSet = tileSets[_tileSetName];
-            tileSet.Add(id);
-            ActiveTileSetValues = tileSet.ToArray();
-        }
+        var tileSet = tileSets[_tileSetName];
         
+        // Always add the tile (allows duplicates)
+        tileSet.Add(id);
+            
+        ActiveTileSetValues = tileSet.ToArray();
         ProfileManager.Save();
     }
 
     private void RemoveFromTileSet(ushort id)
     {
-        if (CEDGame.MapManager.UseSequentialTileSet)
-        {
-            var tileSets = LandMode ? 
-                ProfileManager.ActiveProfile.SequentialLandTileSets : 
-                ProfileManager.ActiveProfile.SequentialStaticTileSets;
-                
-            var tileSet = tileSets[_tileSetName];
-            tileSet.Remove(id);
-            ActiveTileSetValues = tileSet.ToArray();
-        }
-        else
-        {
-            var tileSets = LandMode ?
-                ProfileManager.ActiveProfile.LandTileSets :
-                ProfileManager.ActiveProfile.StaticTileSets;
-                
-            var tileSet = tileSets[_tileSetName];
-            tileSet.Remove(id);
-            ActiveTileSetValues = tileSet.ToArray();
-        }
-        
+        var tileSets = LandMode ? 
+            ProfileManager.ActiveProfile.LandTileSets : 
+            ProfileManager.ActiveProfile.StaticTileSets;
+            
+        var tileSet = tileSets[_tileSetName];
+        tileSet.Remove(id);
+        ActiveTileSetValues = tileSet.ToArray();
         ProfileManager.Save();
     }
 


### PR DESCRIPTION
# PR Summary: Sequential Tile Sets Implementation

## Overview
This PR adds sequential tile set functionality to CentrEDSharp, allowing users to place tiles in a specific, predefined order rather than just randomly selecting from a tile set. This provides more control for creating patterns and sequences when editing maps.

## Key Features
1. **Sequential Tile Set Storage**: Added separate storage for sequential tile sets distinct from the random tile sets
   - Implemented for both land tiles and static tiles
   - Sequential sets maintain order of tiles while traditional sets continue to use SortedSets

2. **Tile Placement Controls**: 
   - Added ability to cycle through tile set values in sequence when placing tiles
   - Added a tracking index to remember position in the sequence
   - Implemented a system to get the next tile in sequence when placing

3. **UI Enhancements**:
   - Added Up/Down buttons in context menu to reorder tiles within a sequential set
   - Updated UI to show appropriate controls only when in sequential mode
   - Added visual indication of sequential mode in the Tile Sets panel

4. **User Experience Improvements**:
   - Preview of tile sets shows the first tile in a sequential set
   - Maintained compatibility with existing random tile sets
   - Added ability to allow duplicate tiles in sequential sets (unlike random sets)

## Technical Implementation
- Modified the TilesWindow class to handle both types of tile sets
- Added new methods for managing sequential tile ordering (MoveSequentialTileAtIndex)
- Added helper method to determine the appropriate tile set collection to use
- Implemented GetNextSequentialId method to retrieve the next tile in sequence
- Enhanced tile set management to preserve order when adding/removing tiles

## Compatibility
This implementation maintains backward compatibility with existing tile sets and profiles, with no breaking changes to existing functionality.