### PR TITLE
fix(tile-rendering): improve invalid tile handling and display logic

### DIFF
--- a/CentrED/Map/MapManager.cs
+++ b/CentrED/Map/MapManager.cs
@@ -326,7 +326,13 @@ public class MapManager
         var landIds = new List<int>();
         for (int i = 0; i < tdl.LandData.Length; i++)
         {
-            if (!UoFileManager.Arts.File.GetValidRefEntry(i).Equals(UOFileIndex.Invalid))
+            var isArtValid = CEDGame.MapManager.UoFileManager.Arts.File.GetValidRefEntry(i).Length > 0;
+
+            ushort texId = tdl.LandData[i].TexID;
+            var isTexValid = CEDGame.MapManager.UoFileManager.Texmaps.File.GetValidRefEntry(texId).Length > 0;
+
+            // Only show tiles if art OR texture is valid
+            if (isArtValid || isTexValid)
             {
                 landIds.Add(i);
             }

--- a/CentrED/UI/Windows/InfoWindow.cs
+++ b/CentrED/UI/Windows/InfoWindow.cs
@@ -125,7 +125,12 @@ public class InfoWindow : Window
         {
             var landTile = lo.Tile;
             ImGui.Text(LangManager.Get(LAND));
-            var spriteInfo = CEDGame.MapManager.Arts.GetLand(landTile.Id);
+
+            // Check if art exists before calling GetLand()
+            var isArtValid = CEDGame.MapManager.UoFileManager.Arts.File.GetValidRefEntry(landTile.Id).Length > 0;
+            uint artIndex = isArtValid ? (uint)landTile.Id : 0; // Fallback to UNUSED placeholder if no art
+            var spriteInfo = CEDGame.MapManager.Arts.GetLand(artIndex);
+
             if (!CEDGame.UIManager.DrawImage(spriteInfo.Texture, spriteInfo.UV))
             {
                 ImGui.TextColored(ImGuiColor.Red, LangManager.Get(TEXTURE_NOT_FOUND));

--- a/CentrED/UI/Windows/TilesWindow.cs
+++ b/CentrED/UI/Windows/TilesWindow.cs
@@ -745,10 +745,10 @@ public class TilesWindow : Window
             
             return TileInfo.INVALID;
         }
-        if (CEDGame.MapManager.UoFileManager.Arts.File.GetValidRefEntry(index).Length < 0)
-        {
-            return TileInfo.INVALID;
-        }
+
+        // Check if art exists
+        var isArtValid = CEDGame.MapManager.UoFileManager.Arts.File.GetValidRefEntry(index).Length > 0;
+
         SpriteInfo spriteInfo;
         if (_texMode)
         {
@@ -756,7 +756,9 @@ public class TilesWindow : Window
         }
         else
         {
-            spriteInfo = CEDGame.MapManager.Arts.GetLand((uint)index);
+            // If art doesn't exist, get the UNUSED placeholder (index 0)
+            uint artIndex = isArtValid ? (uint)index : 0;
+            spriteInfo = CEDGame.MapManager.Arts.GetLand(artIndex);
         }
         var name = CEDGame.MapManager.UoFileManager.TileData.LandData[index].Name;
         var flags = CEDGame.MapManager.UoFileManager.TileData.LandData[index].Flags.ToString().Replace(", ", "\n");


### PR DESCRIPTION
- Update tile filtering to include tiles with valid art or texture, resolving missing tile display issues.
- Add fallback to UNUSED placeholder art when invalid art IDs are encountered in InfoWindow and TilesWindow. 
- This prevents rendering errors and ensures consistent UI behavior when tile assets are missing.