### PR TITLE
Global filter protection: tools never modify tiles hidden by filters

### DIFF
--- a/CentrED/Map/MapManager.cs
+++ b/CentrED/Map/MapManager.cs
@@ -848,12 +848,20 @@ public class MapManager
         );
     }
 
-    private bool CanDrawLand(LandObject lo)
+    public bool CanDrawLand(LandObject lo)
     {
-        if(!ShowLand || (lo.Tile.Id <= 2 && !ShowNoDraw)) 
+        if(!ShowLand || (lo.Tile.Id <= 2 && !ShowNoDraw))
             return false;
         return WithinZRange(lo.Tile.Z);
     }
+
+    // Tiles hidden by the view filter are read-only for tools; the virtual layer is always editable.
+    public bool CanEdit(TileObject? o) => o switch
+    {
+        LandObject lo => CanDrawLand(lo),
+        StaticObject so => CanDrawStatic(so),
+        _ => true,
+    };
 
     public bool CanDrawStatic(StaticObject so)
     {

--- a/CentrED/Tools/AltitudeGradientTool.cs
+++ b/CentrED/Tools/AltitudeGradientTool.cs
@@ -481,6 +481,10 @@ public class AltitudeGradientTool : Tool
 
     private void CreateGhostTile(LandObject lo, sbyte newZ)
     {
+        // Filtered tiles may be sampled for averages/gradients but never modified.
+        if (!MapManager.CanDrawLand(lo))
+            return;
+
         lo.Visible = false;
         var newTile = new LandTile(lo.LandTile.Id, lo.Tile.X, lo.Tile.Y, newZ);
         var ghostTile = new LandObject(newTile);

--- a/CentrED/Tools/BaseTool.cs
+++ b/CentrED/Tools/BaseTool.cs
@@ -114,14 +114,20 @@ public abstract class BaseTool : Tool
             {
                 foreach (var to in MapManager.GetTiles(AreaStartTile, o, TopTilesOnly))
                 {
-                    InternalApply(to);   
+                    if (MapManager.CanEdit(to))
+                    {
+                        InternalApply(to);
+                    }
                     GhostClear(to);
                 }
                 OnAreaOperationEnd();
             }
             else
             {
-                InternalApply(o);
+                if (MapManager.CanEdit(o))
+                {
+                    InternalApply(o);
+                }
                 GhostClear(o);
             }
         }
@@ -138,7 +144,7 @@ public abstract class BaseTool : Tool
             OnAreaOperationUpdate(o);
             foreach (var to in MapManager.GetTiles(AreaStartTile, o, TopTilesOnly))
             {
-                if (Random.Shared.NextDouble() * 100 < _chance)
+                if (MapManager.CanEdit(to) && Random.Shared.NextDouble() * 100 < _chance)
                 {
                     GhostApply(to);
                 }
@@ -146,7 +152,7 @@ public abstract class BaseTool : Tool
         }
         else
         {
-            if (Random.Shared.NextDouble() * 100 < _chance)
+            if (MapManager.CanEdit(o) && Random.Shared.NextDouble() * 100 < _chance)
             {
                 GhostApply(o);
             }
@@ -164,7 +170,7 @@ public abstract class BaseTool : Tool
                     GhostClear(to);
                 }
             }
-            else
+            else if (MapManager.CanEdit(o))
             {
                 InternalApply(o);
             }
@@ -174,6 +180,8 @@ public abstract class BaseTool : Tool
 
     public override void Apply(TileObject? o)
     {
+        if (!MapManager.CanEdit(o))
+            return;
         GhostApply(o);
         InternalApply(o);
     }

--- a/CentrED/Tools/CoastlineTool.cs
+++ b/CentrED/Tools/CoastlineTool.cs
@@ -137,6 +137,9 @@ public class CoastlineTool : BaseTool
         if (selectedTile == null)
             return;
 
+        if (!mapManager.CanDrawLand(selectedTile))
+            return;
+
         if (_terrainWaterTiles.Contains(selectedTile.Tile.Id))
             return;
 
@@ -161,8 +164,8 @@ public class CoastlineTool : BaseTool
                     if (kvp.Value != null && _terrainWaterTiles.Contains(kvp.Value.Id))
                     {
                         var waterLandObject = mapManager.LandTiles[kvp.Value.X, kvp.Value.Y];
-                        
-                        if (waterLandObject != null)
+
+                        if (waterLandObject != null && mapManager.CanDrawLand(waterLandObject))
                         {
                             if (!MapManager.GhostLandTiles.ContainsKey(waterLandObject))
                             {
@@ -303,6 +306,8 @@ public class CoastlineTool : BaseTool
             {
                 foreach (var existingObject in mapManager.StaticsManager.Get(o.Tile.X, o.Tile.Y))
                 {
+                    if (!mapManager.CanDrawStatic(existingObject))
+                        continue;
                     Client.Remove(existingObject.StaticTile); //Do we need to create a ghost for this?
                 }
             }

--- a/CentrED/Tools/DrawTool.cs
+++ b/CentrED/Tools/DrawTool.cs
@@ -142,6 +142,10 @@ public class DrawTool : BaseTool
         if (o == null)
             return;
 
+        // the virtual layer can resolve to a filtered tile
+        if (!MapManager.CanEdit(o))
+            return;
+
         if (!CanDrawOn(o))
             return;
 
@@ -232,6 +236,9 @@ public class DrawTool : BaseTool
     {
         o = TransformTarget(o);
         if (o == null)
+            return;
+
+        if (!MapManager.CanEdit(o))
             return;
 
         if (_drawMode == (int)DrawMode.REPLACE && o is StaticObject so)

--- a/CentrED/Tools/MeshEditTool.cs
+++ b/CentrED/Tools/MeshEditTool.cs
@@ -615,6 +615,9 @@ public class MeshEditTool : BaseTool
                 if (lo == null)
                     continue;
 
+                if (!MapManager.CanDrawLand(lo))
+                    continue;
+
                 // Create ghost tile
                 sbyte newZ = isBufferZone ? lo.Tile.Z : CalculateNewZ(lo, distance, centerZ);
                 lo.Visible = false;


### PR DESCRIPTION
Anything the view filter hides (Z range, land/static visibility, NoDraw, object id/hue filters) are converted to read-only. 

Enforced in BaseTool for every tool plus the multi-tile writers (MeshEdit, Altitude Gradient, Coastline, Draw via virtual layer), hidden tiles cannot be affected.

Filtered tiles can still be sampled for averages and gradients.